### PR TITLE
Add iteration traceability sections to VistterStream planning docs

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,80 +1,167 @@
-# Product Requirements Document (PRD): VistterStream Appliance
+# Product Requirements Document (PRD): Vistter Platform — VistterStream Appliance Focus
 
-## 1. Elevator Pitch
+## 1. Product Overview
+Vistter is an end-to-end platform for producing live and scheduled video streams. It consists of two primary products:
 
-VistterStream is the local streaming appliance that connects on-premises cameras to VistterStudio cloud timelines. Running on hardware like the Raspberry Pi in a Docker container, VistterStream discovers, manages, and processes local cameras, including PTZ (pan-tilt-zoom) presets. It ingests RTSP/RTMP feeds, applies overlays and instructions received from VistterStudio, and streams the final output to destinations such as YouTube Live, Facebook Live, or Twitch. With live previews, health monitoring, and FFmpeg-based processing, VistterStream turns commodity IP cameras into a reliable broadcast node.
+* **VistterStream** — an on-premises appliance that ingests camera feeds, executes show timelines, renders overlays, and distributes the encoded program feed to streaming destinations.
+* **VistterStudio** — a cloud-hosted (firewalled) timeline editor and control surface that author VistterStream appliances subscribe to for orchestration instructions, assets, and monitoring directives.
 
-## 2. Who is this app for
+This PRD focuses on the first shippable version of **VistterStream** while capturing the integration touchpoints that must exist for future VistterStudio control. The appliance must operate reliably on commodity edge hardware (e.g., Raspberry Pi, Intel NUC), expose a local-first configuration experience, and maintain a secure outbound channel to VistterStudio in order to receive instructions despite inbound firewall restrictions.
 
-* **Small businesses & venues**: Shops, restaurants, marinas, and tourist attractions that want to broadcast local camera feeds with professional overlays.
-* **Community organizations**: Visitor bureaus or chambers of commerce showcasing scenic views or events.
-* **Property managers & real estate**: Broadcasting properties or scenic angles with dynamic overlays.
-* **Event operators**: Local operators who need reliable camera-to-stream appliances without managing cloud infrastructure.
+## 2. Product Goals
+* **Establish the Vistter platform foundations** by delivering an appliance that can be controlled by VistterStudio through a defined outbound integration channel.
+* **Preserve local camera investments** by making it easy to onboard stationary and PTZ cameras without bespoke configuration.
+* **Deliver broadcast-ready streams** with synchronized overlays and camera motions driven by VistterStudio or local fallback automation.
+* **Remain self-reliant offline** so that timelines, overlays, VistterStudio-authored segments, and fallback media continue operating during cloud or VistterStudio outages.
+* **Provide operational transparency** with health monitoring, alerts, and auditability for both local operators and remote supervisors.
 
-## 3. Functional Requirements
+## 3. Stakeholders & Personas
+| Persona | Goals | Pain Points Addressed |
+| --- | --- | --- |
+| **Local Operator** (shop owner, venue manager) | Configure cameras, verify previews, ensure stream reliability. | Complex camera setups, lack of technical expertise, limited time.
+| **Remote Producer** (VistterStudio editor) | Author timelines, trigger shows, monitor execution remotely. | Cannot directly reach appliances behind firewalls; needs actionable feedback.
+| **System Admin / IT** | Maintain security, firmware, and appliance updates. | Mixed hardware fleet, sensitive credentials, inbound firewall restrictions.
+| **Advertiser/Partner** | Ensure overlays/ads play on schedule with proof of performance. | Needs verification when remote connectivity is intermittent.
+| **Platform Product Team** | Validate platform architecture and integration before expanding VistterStudio. | Requires clarity on contracts between products and phased roadmap.
 
-### Camera & PTZ Management
+## 4. Scope Definition
+* **In Scope (VistterStream v1.0)**
+  * Local web application for appliance configuration, monitoring, and maintenance.
+  * Camera discovery, manual addition, and PTZ preset management.
+  * Outbound, firewall-friendly integration with VistterStudio for timeline execution, overlay ingestion, segment synchronization, and reporting.
+  * Streaming to one or more destinations with configurable encoding profiles.
+  * Local library to sync, validate, and manually trigger VistterStudio-authored segments for offline or operator-driven playback.
+  * Logging, health telemetry, and status notifications surfaced locally and sync’d back to VistterStudio when connectivity exists.
+  * Definition of the API contracts (events, commands, acknowledgements) between VistterStream and VistterStudio.
+* **Out of Scope (for initial release)**
+  * Authoring workflows inside VistterStudio beyond the minimal surfaces required for integration testing.
+  * On-device video editing beyond overlay composition.
+  * Automated firmware updates for third-party camera hardware.
+  * Native mobile applications (responsive web only).
 
-* **Camera Types:** Support for RTSP/RTMP cameras starting with Reolink (stationary) and Amcrest/Samba (PTZ).
-* **Generic Camera Add:** Ability to add any RTSP/RTMP source via IP/port, credentials, and stream parameters.
-* **PTZ Presets:** Users can define presets ("shots") for PTZ cameras (e.g., `camera1, shot1`, `camera1, shot2`).
-* **Preset Execution:** VistterStream can move PTZ cameras to the correct preset when executing VistterStudio timelines.
-* **Health Monitoring:** Real-time camera connection status, stream errors, and online/offline detection.
+## 5. Detailed Use Cases
+| ID | Title | Primary Actor | Preconditions | Main Flow | Alternate / Exception Flows |
+| --- | --- | --- | --- | --- | --- |
+| UC-01 | First-time Appliance Setup | Local Operator | Appliance powered, connected to LAN. | 1. Operator accesses appliance via default URL. 2. Completes guided setup (timezone, credentials, outbound connection key). 3. Confirms system health baseline. | Network unreachable → show troubleshooting steps; outbound validation fails → provide proxy instructions. |
+| UC-02 | Establish Trust with VistterStudio | System Admin | UC-01 complete; outbound internet available. | 1. Operator retrieves pairing code/token from VistterStudio. 2. Appliance opens outbound TLS channel and presents credentials. 3. Exchange device capabilities and configuration schemas. | Firewall blocks outbound ports → retry with alternative ports; token expired → request regeneration. |
+| UC-03 | Camera Onboarding | Local Operator | UC-01 complete, operator authenticated. | 1. Start camera discovery or manual add. 2. Enter IP, protocol, credentials. 3. Test connection with preview. 4. Save camera config to appliance. | Connection test fails → provide actionable error; unsupported protocol → escalate with help link. |
+| UC-04 | PTZ Preset Creation | Local Operator | PTZ-capable camera configured. | 1. Select camera and open PTZ controls. 2. Adjust pan/tilt/zoom with live preview. 3. Save preset name (e.g., “Front Entrance – Wide”). | PTZ command times out → retry guidance; camera offline → mark preset pending. |
+| UC-05 | Timeline Synchronization | Remote Producer | Cameras and presets exist; VistterStudio timeline scheduled. | 1. VistterStudio publishes upcoming timeline events to message queue/topic. 2. Appliance downloads assets and pre-roll instructions. 3. Appliance acknowledges readiness, then executes steps at runtime. | Message delivery delayed → run local schedule; asset download fails → use cached fallback asset. |
+| UC-06 | Manual Stream Control | Local Operator | Streams configured; operator authenticated. | 1. From dashboard, choose destination. 2. Start or stop stream. 3. View status, bitrate, errors. | Destination rejects key → prompt to update credentials; health thresholds exceeded → surface warnings. |
+| UC-07 | Overlay Synchronization | Remote Producer | Valid VistterStudio credentials cached. | 1. Appliance receives overlay manifest. 2. Downloads assets into cache. 3. Validates checksums and availability. | Download fails → retries with exponential backoff; cache full → prompt cleanup. |
+| UC-08 | Overlay Scene Playback | Control & Orchestration Service | Overlay assets cached; stream encoder healthy. | 1. VistterStudio publishes overlay orchestration script (scenes, layers, timing). 2. Appliance validates script against supported schema. 3. Overlay service executes scenes (fades, position changes, slide swaps) in sync with stream timeline. | Unsupported directive → fall back to safe defaults and log warning; timing drift detected → resync using timeline heartbeat. |
+| UC-09 | Segment Import & Local Playback | Local Operator | Appliance paired with VistterStudio; segment package available. | 1. Operator selects "Import Segment" in Timelines view. 2. Appliance retrieves VistterStudio-authored segment (timeline slice + overlays) via sync channel or removable media. 3. Operator queues or manually plays segment locally, optionally chaining with live inputs. | Segment validation fails → provide error log and fallback slate; offline scenario → operator loads from USB/export package. |
+| UC-10 | Incident Response & Recovery | System Admin | Appliance running in production. | 1. Receives alert (camera offline, CPU high, disk full). 2. Reviews diagnostic logs and metrics. 3. Applies corrective action (restart stream, adjust settings). | Appliance unreachable → instructions for physical reboot; persistent failure → escalate to support. |
+| UC-11 | Third-Party Destination Streaming | Local Operator | Destination credentials configured. | 1. Operator selects YouTube/Facebook/Twitch profile. 2. Appliance validates stream key and handshake. 3. Stream engine routes encoded output per schedule. | Destination rejects stream → present troubleshooting steps; bandwidth insufficient → auto-adjust bitrate and alert operator. |
 
-### Web Interface (Local Only)
+## 6. Functional Requirements
+### 6.1 Platform Integration
+* Provide an outbound-only connectivity model using TLS (WebSocket, MQTT, or HTTPS long poll) so appliances behind firewalls can receive commands without inbound port exposure.
+* Support device registration, credential rotation, and revocation initiated from VistterStudio.
+* Define a command schema for timelines (start/stop, preset move, overlay change, health request) with versioning and backward compatibility guarantees.
+* Buffer incoming commands for at least 60 seconds during transient connectivity loss and reconcile once the channel resumes.
+* Publish acknowledgements, telemetry, and error events back to VistterStudio within 3 seconds of processing.
 
-* **Authentication:** Simple username/password login with ability to change credentials.
-* **Add/Remove Cameras:** Web forms to configure IP address, port, credentials, stream path.
-* **PTZ Configuration:** Interface to save and test PTZ preset positions.
-* **Live Previews:** Embedded video preview for each camera feed.
-* **Status Dashboard:** Camera health, system resource usage, and stream status.
+### 6.2 Camera & PTZ Management
+* Discover ONVIF-compatible cameras and allow manual RTSP/RTMP entry.
+* Validate camera connectivity (ping, auth, stream negotiation) before saving.
+* Store unlimited presets per PTZ camera; map presets to VistterStudio shot identifiers.
+* Provide test-and-save workflow for PTZ presets with snap-to-position confirmation.
+* Maintain camera state (online/offline, last heartbeat, current preset) and expose updates to VistterStudio.
 
-### Streaming & Processing (FFmpeg)
+### 6.3 Timeline & Overlay Execution
+* Subscribe to VistterStudio timeline events via secure channel and schedule execution with millisecond precision.
+* Execute timeline steps with deterministic ordering: preset move → overlay update → stream routing.
+* Cache overlay assets locally with versioning and fallback media.
+* Import and catalog VistterStudio-authored **Segments** (encapsulated timeline slices with overlays and metadata) for both scheduled execution and manual local playback, including support for offline package ingestion.
+* Interpret **Overlay Composition Language (OCL)** payloads that describe scenes, layers, transitions, and property automation (opacity, transforms, text tokens) with deterministic timing.
+* Support time-relative (`t+`) and absolute (`00:01:23.500`) cues, transition definitions (fade, wipe, cut), z-order priorities, and layout anchors within the safe-title grid.
+* Validate OCL payloads with schema versioning, reject unknown directives gracefully, and publish validation errors back to VistterStudio.
+* Report execution metrics (latency, success/failure, active preset, overlay scene status) back to VistterStudio.
+* Provide operator controls to queue, preview, and manually trigger imported segments while logging actions and notifying VistterStudio of local overrides.
+* Allow locally-authenticated operators to trigger manual overrides that are logged and relayed to VistterStudio (e.g., pause overlays, pin emergency slate).
 
-* **Ingest:** Pull RTSP/RTMP feeds from configured cameras.
-* **Overlay Pipeline:** Apply overlays and assets (ads, weather, promos) received from VistterStudio.
-* **Transcoding:** Adjust resolution, codecs, and bitrates for compatibility with destinations.
-* **Multi-Output:** Support streaming to multiple services simultaneously (YouTube Live, Facebook Live, Twitch).
-* **Failover:** Replace failed feeds with placeholder or alternate camera.
-* **Logging:** Maintain logs for stream errors, restarts, and system health.
+### 6.4 Streaming & Processing
+* Support concurrent streaming to at least three destinations with configurable encoding profiles.
+* Provide bitrate, resolution, and keyframe configuration per destination.
+* Automatically recover from FFmpeg crashes with bounded retries and exponential backoff.
+* Insert slate/fallback feed when source camera fails to deliver frames within threshold.
+* Support optional recording of program output for later upload once bandwidth is available.
 
-### Storage & Config
+### 6.5 Local Web Experience
+* Role-based access: Operator (camera/stream actions) and Admin (system configuration).
+* Dashboard with live previews, health widgets, and recent activity log including VistterStudio command history.
+* Wizards for onboarding (setup, camera add, VistterStudio pairing) and guided troubleshooting.
+* System settings to manage credentials, network configuration, backups, and software updates.
 
-* **Lightweight Database:** SQLite (or equivalent) to store camera configurations, PTZ presets, and credentials securely.
-* **Cache:** Local caching of overlay assets, media, and fallback images.
-* **Persistence:** Automatic restoration of configuration after reboot.
+### 6.6 Observability & Maintenance
+* Collect and store system metrics (CPU, GPU, memory, disk, network throughput) with 24-hour retention.
+* Provide downloadable diagnostic bundle (logs, configs, metrics snapshots).
+* Send optional webhook/email alerts for critical incidents (stream failure, storage near capacity).
+* Expose API endpoints for remote monitoring/automation (read-only tokens) and forward summaries to VistterStudio.
+* Record overlay and segment playback audit trails, including cue execution timestamps, asset identifiers, segment identifiers, and operator overrides for advertiser proof-of-play.
 
-### Cloud Integration (VistterStudio)
+### 6.7 Overlay Composition Language Definition
+* Provide a JSON-based schema (`ocl`) that encapsulates:
+  * `timeline` metadata (id, version, frame rate, base resolution).
+  * `assets` manifest with secure URLs, checksums, media type, and usage rights tags.
+  * `scenes` array containing ordered `tracks` (background, lower-third, fullscreen slide) with cues specifying `start`, `duration`, `layer`, `assetRef`, `transition`, `properties` (opacity, position, scale, text fields), and `automation` envelopes for property tweening.
+  * `sync` directives to lock cues to camera presets or stream milestones (e.g., `awaitPreset("Front Entrance – Wide")`).
+  * `fallbacks` block specifying safe-state overlays if assets missing or validation fails.
+* Ensure schema documentation is published for VistterStudio team and versioned for backward compatibility.
+* Support inline localization tokens (e.g., `{{locationName}}`) to be resolved by VistterStream before render.
 
-* **Timeline Execution:** Receive instructions from VistterStudio to switch cameras and PTZ shots according to timelines.
-* **Overlay Sync:** Download overlay assets and data (ads, weather, promos) from VistterStudio.
-* **Execution Feedback:** Report status, errors, and health back to VistterStudio for monitoring.
 
-## 4. User Stories
+## 7. Non-functional Requirements
+* **Availability:** 99% appliance uptime when powered and networked; VistterStudio command channel uptime ≥ 98%.
+* **Latency:** Camera preset execution + overlay activation < 2 seconds end-to-end under nominal conditions; command acknowledgement back to VistterStudio < 3 seconds.
+* **Security:** Enforce encrypted credential storage, TLS for local UI (self-signed allowed), audit login attempts, and mutual authentication with VistterStudio control plane.
+* **Performance:** Support 1080p60 ingest for up to three cameras concurrently on reference hardware; OCL renderer must composite at least three overlay layers at 60fps without dropped frames.
+* **Scalability:** Architecture must allow clustering/fleet management in future without rework (stateless controller APIs, tenant-aware identifiers).
+* **Reliability:** Survive network blips up to 60 seconds without manual intervention with queued command replay.
+* **Maintainability:** Configuration represented as versioned schema with migration tooling and remote diff visibility within VistterStudio.
 
-* **As a business owner,** I want to add my Reolink camera into VistterStream so that I can preview and broadcast it.
-* **As a property manager,** I want to define PTZ presets so that I can show different angles of the same camera during a broadcast.
-* **As a timeline editor in VistterStudio,** I want to reference `camera1, shot2` so that the correct PTZ position is shown in the livestream.
-* **As a broadcast operator,** I want to monitor camera health so that I know if a feed goes down.
-* **As a system admin,** I want simple local authentication so that only authorized people can configure cameras.
-* **As a streamer,** I want the appliance to automatically push streams to YouTube Live so that I don’t have to manage FFmpeg manually.
-* **As a location operator,** I want cached overlays to still display even if cloud connectivity is lost.
+## 8. Dependencies & Assumptions
+* Hardware provides hardware-accelerated decoding/encoding (Pi GPU, Intel Quick Sync) or falls back to software.
+* VistterStudio exposes authenticated APIs or message broker endpoints for timeline directives, overlay manifests, overlay composition language payloads, segment packages, and status callbacks.
+* Firewall policies allow outbound connectivity from the appliance to VistterStudio control endpoints and streaming destinations.
+* Operators will have physical access to appliance for recovery procedures.
+* VistterStudio implements minimal UI flows to issue pairing tokens, view appliance telemetry, and resend commands for testing.
+* Streaming destinations such as YouTube Live, Facebook Live, Twitch, and custom RTMP endpoints accept outbound streams from VistterStream once credentials validated.
 
-## 5. User Interface
+## 9. Release Considerations
+* **MVP Success Criteria:** At least two camera types supported (one stationary, one PTZ); single timeline execution driven by VistterStudio via outbound channel; dual destination streaming; operator dashboard with health metrics and VistterStudio command history.
+* **Future Enhancements:** Multi-appliance fleet management, AI-based anomaly detection, integration with advertising analytics, LTE/cellular fallback, deeper VistterStudio editing tools.
+* **Open Questions:** Desired SLA for alert delivery? Should appliance support offline authoring when VistterStudio unreachable? How will licensing of third-party codecs be handled? What message broker will VistterStudio expose (managed MQTT vs. HTTPS push)? How often will OCL schema evolve and how will backward compatibility be maintained across appliance firmware versions?
 
-* **Login Page:** Username/password authentication.
-* **Dashboard:** Camera list with thumbnails, connection status, and live previews.
-* **Add Camera Form:** Fields for camera name, type (stationary/PTZ), IP, port, credentials, stream path.
-* **PTZ Preset Manager:** Interface to save and test presets, with labels like "shot1," "shot2."
-* **Status Dashboard:** System health (CPU, memory), camera connectivity, active outputs.
-* **Settings:** Manage authentication, storage usage, and streaming destinations.
+## 10. Iteration Framework & Traceability
+### 10.1 Document Status Checkpoints
+| Area | Current Maturity | Next Validation Step | Owner |
+| --- | --- | --- | --- |
+| Product Goals & Scope | Draft aligned across platform leads | Review with GTM stakeholders to validate positioning | Product Manager |
+| Use Case Catalog | Comprehensive v1 covering core appliance flows | Add edge cases for multi-appliance scenarios | Product & Engineering |
+| Functional Requirements | Draft with integration emphasis | Map to API contract backlog and implementation tickets | Product & Tech Leads |
+| Non-functional Requirements | Draft with performance/security targets | Benchmark against reference hardware prototypes | Engineering |
 
-## 6. Technical Notes
+### 10.2 Use Case Coverage Matrix
+| Use Case ID | Key Requirements | Notes |
+| --- | --- | --- |
+| UC-01, UC-02 | 6.1, 6.5 | Validate setup wizard copy and firewall guidance with pilot customers. |
+| UC-03, UC-04 | 6.2, 6.5 | Confirm PTZ preset schema aligns with VistterStudio shot IDs. |
+| UC-05, UC-08 | 6.1, 6.3, 6.7 | Stress-test command buffering during simulated outages. |
+| UC-06, UC-11 | 6.4 | Capture credential rotation workflow for each streaming destination. |
+| UC-07 | 6.3, 6.7 | Define overlay asset retention policy and cache eviction triggers. |
+| UC-09 | 6.3, 6.6 | Document operator permissions for manual segment playback overrides. |
+| UC-10 | 6.6 | Align incident escalation paths with support SLAs. |
 
-* **Deployment:** Docker container on Raspberry Pi or local Linux device.
-* **Processing Engine:** FFmpeg for ingest, overlay composition, transcoding, and output.
-* **Security:** Configurations stored securely, passwords encrypted, local-only access.
-* **Extensibility:** Camera integration layer designed for additional vendors in future.
-* **Resilience:** Auto-reconnect logic for unstable camera feeds.
-* **Integration:** Tight coupling with VistterStudio timelines and overlays for synchronized storytelling.
+### 10.3 Requirements Backlog for Next Revision
+1. Define explicit telemetry event taxonomy shared with VistterStudio (success, warning, error codes).
+2. Capture appliance-to-Studio credential rotation lifecycle (request, approval, revocation) and required UI surfaces.
+3. Specify localization strategy for OCL tokens and operator UI (supported locales, fallback behavior).
+4. Detail resiliency expectations for offline-only operation (maximum duration, required operator tooling).
+5. Document compliance and privacy requirements for recorded streams and audit logs per region.
 
+### 10.4 Decision Log References
+* **DL-001:** Outbound-only command channel chosen to satisfy firewall constraints—revisit once reverse proxy option explored.
+* **DL-002:** JSON-based OCL schema selected for human readability and Studio compatibility—evaluate binary formats after MVP.
+* **DL-003:** Local web UI prioritized over native clients—reconsider after multi-appliance fleet management roadmap defined.

--- a/docs/SAD.md
+++ b/docs/SAD.md
@@ -1,127 +1,162 @@
-# VistterStream Software Specification (Raspberry Pi + Mac Development)
+# VistterStream Software Architecture & Specification
 
-## System Design
+## 1. Architectural Overview
+VistterStream is delivered as a containerized appliance that runs on ARM64 (Raspberry Pi) and x86_64 (Mac, Intel NUC) hardware. The system orchestrates IP camera ingest, timeline execution from VistterStudio, overlay rendering, and multi-endpoint streaming. The solution favors modular services within a single container to simplify deployment, while keeping responsibilities explicit for future multi-service evolution.
 
-* Local appliance containerized with Docker.
-* Provides a **web interface** for camera management, PTZ presets, and live previews.
-* Ingests RTSP/RTMP feeds from IP cameras.
-* Executes PTZ preset moves on supported cameras.
-* Uses **FFmpeg** for ingest, overlays, and streaming outputs.
-* Receives overlay/timeline instructions from **VistterStudio**.
-* Designed to run consistently on **Mac (x86_64)** for dev and **Raspberry Pi (ARM64)** for production.
-
-## Architecture Pattern
-
-* **Single-container modular architecture**:
-
-  * **Web UI** (React frontend + served statics).
-  * **API Backend** (FastAPI or Node.js for REST APIs).
-  * **Controller** (manages camera configs, PTZ, state).
-  * **Stream Engine** (FFmpeg wrapper, controlled via API).
-* Separation of concerns: UI ↔ API/Controller ↔ Stream Engine.
-
-## State Management
-
-* **SQLite** for persistent local storage.
-* Stores camera configs, PTZ presets, user auth, destinations.
-* Runtime state (active streams, health metrics) cached in memory.
-* APIs expose state to UI + VistterStudio.
-
-## Data Flow
-
-1. User logs in via **Web UI** → adds/configures cameras.
-2. Config stored in **SQLite**.
-3. **Controller** launches FFmpeg streams via Stream Engine.
-4. FFmpeg ingests, applies overlays, pushes to streaming destinations.
-5. Health & status metrics reported back to Controller → UI.
-6. VistterStudio sends timeline instructions → Controller switches camera/PTZ presets accordingly.
-
-## Technical Stack
-
-* **Frontend:** React + Tailwind.
-* **Backend API:** FastAPI (Python) or Node.js/Express.
-* **Database:** SQLite.
-* **Streaming Engine:** FFmpeg (multi-arch build).
-* **Containerization:** Docker with Buildx (multi-arch: x86_64 & ARM64).
-* **Build Process:** CI/CD generates multi-platform images with manifest lists.
-
-## Authentication Process
-
-* Local username/password auth.
-* Passwords hashed (bcrypt).
-* Configurable via UI.
-* Session cookies or JWT for web sessions (local-only).
-
-## Route Design
-
-* **/auth** → login, change password.
-* **/cameras** → CRUD for cameras, connection test, health.
-* **/presets** → CRUD for PTZ presets, move/test.
-* **/streams** → start/stop streams, status.
-* **/status** → system metrics (CPU, memory, camera health).
-* **/overlays** → sync overlays from VistterStudio.
-
-## API Design
-
-* REST API with JSON.
-* Example camera add:
-
-```http
-POST /cameras
-{
-  "name": "Reolink Front",
-  "type": "PTZ",
-  "protocol": "RTSP",
-  "address": "rtsp://user:pass@192.168.1.50:554/stream1"
-}
+```
++-----------------------+         +-----------------------+
+|     Local Browser     |<------->|  Web/API Gateway      |
++-----------------------+         +-----------------------+
+                                            |
+                                            v
+                              +---------------------------+
+                              |   Control & Orchestration  |
+                              +---------------------------+
+                              /             |             \
+                             v              v              v
+                   +---------------+  +-------------+  +------------+
+                   | Camera/Device |  | Stream      |  | Overlay    |
+                   | Manager       |  | Engine      |  | Service    |
+                   +---------------+  +-------------+  +------------+
+                             \              |              /
+                              v             v             v
+                         +-------------------------------------+
+                         | Persistence, Metrics, & Messaging   |
+                         +-------------------------------------+
 ```
 
-* Example PTZ preset:
+## 2. Quality Attribute Priorities
+1. **Reliability:** Streams must recover automatically and timelines must execute even with transient failures.
+2. **Observability:** Operators require actionable telemetry to maintain the appliance remotely.
+3. **Security:** Local-only access with secure credential handling and auditable operations.
+4. **Portability:** Same codebase runs across target hardware via Docker multi-arch builds.
+5. **Extensibility:** Components are loosely coupled to allow future cloud orchestration or clustering.
 
-```http
-POST /cameras/{id}/presets
-{ "name": "shot1", "pan": 0, "tilt": 30, "zoom": 2 }
-```
+## 3. Component Responsibilities
+| Component | Responsibilities | Key Interfaces |
+| --- | --- | --- |
+| **Web/API Gateway** | Serves React UI, exposes REST/WebSocket APIs, handles authentication, enforces RBAC. | HTTPS, WebSocket, session cookies/JWT. |
+| **Control & Orchestration Service** | Normalizes timelines and imported segments, coordinates camera moves, overlay activation, and stream commands. Maintains state machine per timeline or segment playback session. | Internal gRPC/REST calls to Camera Manager, Stream Engine, Overlay Service. |
+| **Camera/Device Manager** | Discovers cameras (ONVIF), maintains connection pools, issues PTZ commands, verifies heartbeats. | ONVIF/RTSP clients, internal command bus, metrics emitter. |
+| **Stream Engine** | Wraps FFmpeg workers, manages encoding profiles, handles retries, produces health metrics. | Process supervisor, IPC for command/control, file system for assets. |
+| **Overlay Service** | Syncs assets from VistterStudio, validates manifests, compiles Overlay Composition Language (OCL) scripts, and provides rasterized/HTML overlays to Stream Engine. Caches overlay payloads referenced by imported segments for offline playback. | HTTPS downloads, OCL validator, scene runtime API, integrity checker. |
+| **Persistence Layer** | SQLite database + encrypted secrets vault storing configuration, presets, credentials, audit logs. | ORM/Data access layer. |
+| **Metrics & Messaging Layer** | Collects Prometheus-style metrics, event bus for local alerts, optional webhook dispatcher. | Metrics endpoint, webhook clients. |
 
-## Database Design ERD
+## 4. Data Models & Storage
+* **Configuration Database (SQLite):** Cameras, presets, stream profiles, credentials (encrypted), appliance settings, audit trails, imported segment metadata (version, source, last validation timestamp).
+* **Asset Cache (Filesystem):** Overlay images/videos, fallback slates, OCL scene caches, with version manifest for validation.
+* **Overlay Composition Scripts:** Parsed/validated JSON persisted with schema version and compilation checksum for deterministic playback.
+* **Telemetry Store (Time-Series):** Lightweight ring buffer (e.g., SQLite table or embedded TSDB) retaining 24–48 hours of metrics and events.
+* **Secrets Management:** Credentials encrypted with appliance-specific key stored in secure enclave or OS keyring.
 
-```mermaid
-erDiagram
-  USER {
-    int id PK
-    string username
-    string password_hash
-  }
+## 5. Interface Contracts
+* **REST API:** CRUD endpoints for cameras, presets, streams, overlays, system settings. JSON schema versioned and documented via OpenAPI.
+* **WebSocket/API Events:** Push timeline updates, health notifications, alert streams to the UI and optionally VistterStudio.
+* **Timeline Ingress:** Authenticated channel (HTTPS webhook or MQTT) from VistterStudio delivering timeline steps, overlay references, OCL payloads, segment packages, and scheduling metadata.
+* **Segment Import Interface:** Offline-capable loader (USB/SMB/package upload) that validates signed segment bundles before registering them for manual playback.
+* **Overlay Runtime API:** Internal API (`/overlay/runtime`) exposing commands to preload scenes, start/stop cues, adjust dynamic tokens, and report cue completion back to orchestration service.
+* **Stream Command Bus:** Internal queue (e.g., Redis Streams or in-process dispatcher) issuing start/stop/restart commands to FFmpeg workers.
 
-  CAMERA {
-    int id PK
-    string name
-    string type
-    string protocol
-    string address
-    string username
-    string password_enc
-  }
+## 6. Runtime Scenarios
+### 6.1 Camera Onboarding Flow
+1. User submits camera configuration through Web UI.
+2. API Gateway validates payload and stores draft record.
+3. Camera Manager tests connectivity (RTSP handshake, credential auth).
+4. On success, configuration committed and preview token generated; on failure, result surfaced to UI with diagnostics.
 
-  PRESET {
-    int id PK
-    int camera_id FK
-    string name
-    float pan
-    float tilt
-    float zoom
-  }
+### 6.2 Timeline Execution Flow
+1. Timeline instruction arrives from VistterStudio.
+2. Orchestration Service locks associated resources (camera, stream).
+3. Camera Manager executes PTZ move and confirms completion.
+4. Overlay Service parses OCL payload, preloads required assets, and schedules cues relative to timeline clock.
+5. Stream Engine activates encoding pipeline and routes to destinations.
+6. Overlay Runtime triggers cue transitions (fade in/out, opacity adjustments, slide changes) and notifies orchestration service on completion.
+7. Execution results and metrics (including overlay cue latency) are reported back via WebSocket and VistterStudio callback.
 
-  STREAM {
-    int id PK
-    int camera_id FK
-    string destination
-    string status
-    datetime started_at
-  }
+### 6.3 Overlay Orchestration Flow
+1. VistterStudio publishes OCL document referencing asset bundle and schema version.
+2. Overlay Service fetches document, validates against JSON schema, and stores compiled scene graph.
+3. Control Service issues `prepareScene(sceneId)` prior to showtime; Overlay Service ensures textures, fonts, and animations staged.
+4. When timeline clock hits cue start, Overlay Service issues render instructions to Stream Engine overlay compositor (e.g., HTML canvas, WebGL, or FFmpeg filter graph).
+5. During playback, OCL automation curves adjust properties (opacity, scale) and event hooks emit telemetry (cueStarted, cueCompleted, cueFallback).
+6. If validation or rendering fails, fallback overlay defined in OCL is applied and error surfaced to both local UI and VistterStudio.
 
-  USER ||--o{ CAMERA : manages
-  CAMERA ||--o{ PRESET : has
-  CAMERA ||--o{ STREAM : streams
-```
+### 6.4 Failure Recovery Flow
+1. Stream Engine detects frame loss or FFmpeg exit code.
+2. Control Service triggers retry with exponential backoff, optionally swapping to fallback feed.
+3. Metrics layer records incident; alert dispatched to UI and configured webhooks.
+4. After max retries, stream marked degraded, operator prompted for manual intervention.
 
+### 6.5 Local Segment Playback Flow
+1. Operator selects an imported segment from the Timelines view or quick action list.
+2. Control Service loads associated timeline slice, overlay cues, and media references from persistence.
+3. Overlay Service ensures assets are cached locally and validates integrity hashes; Stream Engine primes corresponding profiles.
+4. Operator triggers manual play; Control Service starts the segment clock, issuing camera/overlay/stream commands in recorded order.
+5. Completion events and any overrides are logged locally and, when connected, synchronized back to VistterStudio for audit.
+
+## 7. Deployment View
+* **Containerization:** Single Docker image with multi-stage build bundling frontend, backend, FFmpeg binaries, and headless renderer runtime for OCL scenes (e.g., Node/Chromium or GPU-accelerated compositor).
+* **Process Model:** Supervisor process (e.g., uvicorn/gunicorn) runs API Gateway; background workers (async tasks or Celery-like) manage orchestration and FFmpeg lifecycles.
+* **Configuration:** Environment variables for hardware-specific options, mount for persistent volume storing SQLite DB, cache, and logs.
+* **Networking:** Expose HTTPS (443/8443) locally, optional SSH for support. Outbound firewall rules for streaming destinations and VistterStudio APIs.
+* **Updates:** OTA update script downloads signed image, verifies checksum, performs rolling restart with rollback capability.
+
+## 8. Security Considerations
+* TLS termination on appliance with auto-generated cert; allow custom cert upload.
+* Bcrypt/Argon2 password hashing, salted and stretched.
+* Role-based authorization enforced per endpoint; audit log for configuration changes and login attempts.
+* Secrets at rest encrypted with hardware-backed key when available.
+* Optional IP allowlist for UI access; CSRF protection on state-changing endpoints.
+
+## 9. Scalability & Extensibility
+* Design allows horizontal scaling by externalizing persistence and message bus; controllers can become stateless microservices.
+* Abstract camera and stream drivers to plug in additional vendors or protocols without touching orchestration core.
+* Provide feature flags for experimental overlays or AI modules without redeploying base appliance.
+
+## 10. Observability & Operations
+* Metrics endpoint (Prometheus format) exposes system health, stream bitrate, frame drops, PTZ latency.
+* Structured logging (JSON) with correlation IDs for timeline steps, segment executions, and overlay cues; logs shipped to local file and optional remote sink.
+* Health checks: liveness for container runtime, readiness verifying DB connectivity and FFmpeg worker pool.
+* Diagnostics bundle generator collects logs, configs, metrics snapshots for support tickets.
+
+## 11. Compliance & Testing Strategy
+* Unit tests for camera drivers, overlay manifest parser, and orchestration logic.
+* Integration tests simulating timeline execution, manual segment playback, and mocked FFmpeg responses with OCL overlay playback.
+* Hardware-in-the-loop regression tests for supported camera models and PTZ sequences.
+* Security testing covering credential storage, API auth, TLS configuration, and OWASP top risks.
+* Performance testing measuring CPU/memory under multi-stream load and failover scenarios.
+
+## 12. Risks & Mitigations
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Hardware limitations prevent smooth 1080p streaming. | Dropped frames, unusable stream. | Provide adaptive profiles, hardware acceleration detection, and fallback quality levels. |
+| Overlay sync fails during network outage. | Advertisers miss placements. | Cache assets with manifest versions, allow manual override, provide stale asset warnings. |
+| OCL directive unsupported on legacy firmware. | Overlay scenes render incorrectly during live event. | Implement schema version negotiation, feature flags, and compatibility matrix with automated regression tests per OCL version. |
+| PTZ commands unreliable on certain vendors. | Timeline misses shot transitions. | Vendor-specific adapter layer with retry logic, fallback presets, certification process per camera. |
+| Security breach via default credentials. | Unauthorized access to streams. | Mandatory password reset during setup, password strength checks, optional 2FA roadmap. |
+
+## 13. Open Questions
+* Which protocol (MQTT vs. Webhook) will VistterStudio standardize for timeline delivery?
+* What is the required retention period for audit logs?
+* Do we need built-in cellular failover support for remote locations?
+* Will overlays render via HTML5, vector graphics, or GPU shaders, and how will we package the runtime for both ARM and x86 targets?
+* How will VistterStream expose preview APIs so VistterStudio can validate OCL scenes before going live?
+
+## 14. Traceability to Product Requirements
+| PRD Requirement | Architectural Elements | Validation Approach |
+| --- | --- | --- |
+| 6.1 Platform Integration | Control & Orchestration, Web/API Gateway, Timeline Ingress | Contract tests against mocked VistterStudio endpoints; soak tests for reconnection handling. |
+| 6.2 Camera & PTZ Management | Camera/Device Manager, Persistence Layer | Hardware-in-the-loop regression suite, PTZ command replay logs. |
+| 6.3 Timeline & Overlay Execution | Control Service, Overlay Service, Stream Engine | Scenario simulations executing OCL payloads with telemetry capture. |
+| 6.4 Streaming & Processing | Stream Engine, Metrics Layer | Load testing on reference hardware, failover drills. |
+| 6.5 Local Web Experience | Web/API Gateway, Frontend SPA | UX acceptance tests, accessibility audits. |
+| 6.6 Observability & Maintenance | Metrics & Messaging, Persistence | Synthetic alert pipelines, diagnostics bundle generation tests. |
+| 6.7 Overlay Composition Language | Overlay Service, Asset Cache | Schema validation suite, golden-master rendering comparisons. |
+
+## 15. Architecture Backlog & Next Steps
+1. **Document Control Plane Contracts:** Produce OpenAPI/AsyncAPI specs for inbound commands and outbound telemetry, versioned alongside firmware releases.
+2. **Define Reference Deployments:** Create reproducible Docker Compose stacks for ARM64 and x86_64 hardware to validate portability claims.
+3. **Prototype Overlay Runtime:** Evaluate rendering options (Chromium headless vs. GPU compositor) and document performance benchmarks.
+4. **Security Hardening Plan:** Detail threat model, penetration testing schedule, and certificate rotation strategy before pilot deployments.
+5. **Operational Runbooks:** Draft incident response playbooks aligned with observability metrics and alerting pathways.

--- a/docs/UXD.md
+++ b/docs/UXD.md
@@ -1,98 +1,127 @@
-# VistterStream User Interface Design Document
+# VistterStream User Experience & Interaction Design
 
-## Layout Structure
+## 1. Design Principles
+* **Operational Clarity:** Every view surfaces system status, active streams, and recent alerts without hunting.
+* **Guided Configuration:** Wizards and contextual tips help non-technical operators onboard cameras and presets confidently.
+* **Resilient Feedback:** Real-time validations, optimistic UI states with rollback, and persistent toasts keep users informed during timeline execution.
+* **Responsive Reliability:** Layout adapts gracefully to tablets and smaller laptops used in control rooms or on-site kiosks.
 
-* **Login Screen:** Simple form for username/password.
-* **Main Dashboard:** Camera overview with previews, health indicators, and quick actions.
-* **Navigation Sidebar:** Links for Dashboard, Cameras, Presets, Streams, Overlays, Settings.
-* **Top Bar:** System status (CPU, memory, active streams), user menu (logout, change password).
+## 2. Information Architecture
+* **Authentication Layer:** Login, password reset, first-time setup wizard.
+* **Primary Navigation:** Dashboard, Cameras, Presets, Timelines, Segments, Streams, Overlays, System (Settings, Logs, Updates).
+* **Secondary Navigation:** Within each section provide tabs (Details, Activity, Diagnostics) to reduce clutter.
+* **Global Elements:** Persistent top bar with health summary, alerts bell, and quick actions (Start Stream, Generate Diagnostics).
 
-## Core Components
+## 3. Key User Journeys
+### 3.1 First-Time Setup
+1. User lands on welcome screen, reads hardware setup checklist.
+2. Guided wizard collects locale/timezone, admin credentials, network preferences.
+3. Final screen summarizes configuration and links to camera onboarding.
 
-1. **Login Page**
+### 3.2 Camera Onboarding & Validation
+1. Operator opens Cameras → "Add Camera" modal.
+2. Form collects camera name, type (stationary/PTZ), protocol, network details, credentials.
+3. Inline validation verifies credentials; preview pane streams sample footage.
+4. Success state stores camera and suggests adding PTZ presets if applicable.
 
-   * Input fields: username, password
-   * Submit button → redirects to Dashboard
-   * Minimal branding with VistterStream logo
+### 3.3 Timeline Monitoring
+1. Remote producer or operator opens Timelines view.
+2. See table of scheduled/active timelines with status chips (Scheduled, Running, Warning, Failed).
+3. Selecting a timeline opens detail drawer showing shot sequence, current step, and upcoming overlays.
+4. Operator can pause/resume timeline or trigger manual override (switch to fallback shot).
 
-2. **Dashboard**
+### 3.4 Overlay Orchestration Monitoring
+1. Producer opens Timelines → selects active show with overlays.
+2. Overlay panel shows current scene, next cue countdown, and layer stack preview.
+3. Producer can trigger manual overrides (pause overlays, force fallback slate) with confirmation dialog.
+4. Cue history lists executed overlays with timestamps for advertiser verification.
 
-   * **Camera Grid:** Tiles with live preview, camera name, status indicator (green/red).
-   * **Quick Actions:** Start/stop stream, go to settings, view logs.
-   * **System Metrics:** CPU, memory, network usage in top bar widget.
+### 3.5 Incident Response
+1. Alert badge indicates new issue; clicking opens Alerts center.
+2. Alert detail page shows severity, affected resource, recommended action, quick links (restart stream, view logs).
+3. Resolution actions change alert state to Resolved with audit trail entry.
 
-3. **Camera Management**
+### 3.6 Manual Segment Playback
+1. Operator opens Segments view to browse synced and offline packages.
+2. Selecting a segment opens detail drawer with timeline steps, required cameras, overlays, and duration.
+3. Operator previews segment playback (picture-in-picture) and queues it to "Next" or triggers immediate play.
+4. Confirmation modal summarizes outputs affected and requests optional note for audit trail.
+5. Upon completion, success banner offers quick link to review execution logs or replay.
 
-   * **Camera List View:** Table or cards with camera name, type (stationary/PTZ), protocol, health.
-   * **Add Camera Form:** Fields for name, type, address, port, credentials.
-   * **Connection Test Button:** Validate camera before saving.
-   * **Edit/Delete Buttons** per camera.
-   * **Preview Pane:** Inline stream preview.
+## 4. Screen Specifications
+| Screen | Layout Details | Key Components |
+| --- | --- | --- |
+| **Login & Setup** | Centered card, dual-column on desktop (login + help panel). Setup wizard uses progress indicator. | Form fields, password strength meter, hardware checklist accordion. |
+| **Dashboard** | Responsive grid: top bar metrics, camera preview tiles, alerts list sidebar. | Metric cards, camera cards (thumbnail, status, actions), alert feed, quick action buttons. |
+| **Cameras** | Table view with filters + inline preview; drawer for camera detail editing. | Data table, filter chips, RTSP test button, connection history timeline. |
+| **Presets** | Split view: left list of presets, right live preview with PTZ controls. | PTZ joystick controls, slider inputs, save/cancel actions, preset tagging. |
+| **Timelines** | Calendar/list toggle, detail drawer showing step sequence. | Timeline progress indicator, overlay thumbnails, override controls, overlay cue timeline scrubber. |
+| **Segments** | Library list with sync status and source (cloud/export). Detail drawer highlights dependencies and offers preview controls. | Segment cards with status badges (Ready, Needs Validation), import/upload button, queue/Play Now actions, execution log panel. |
+| **Streams** | Card layout per destination with status, bitrate graphs, history log. | Start/stop toggle, bitrate sparkline, error log accordion, key management modal. |
+| **Overlays** | Dual-pane view: asset gallery with manifest metadata alongside OCL script preview. | Thumbnail grid, sync status badges, version comparison modal, cue inspector (start time, duration, transition, opacity curve). |
+| **System Settings** | Tabbed interface (General, Network, Updates, Diagnostics). | Form sections, backup/export buttons, OTA update progress widget. |
 
-4. **PTZ Preset Manager**
+## 5. Interaction Patterns & States
+* **Modals** for add/edit actions with autosave drafts when closed unexpectedly.
+* **Drawers** for quick inspection without navigating away (camera details, timeline steps, overlay cue inspector).
+* **Segment Queue Controls** allow drag-and-drop ordering of upcoming manual segments with clear execution targets (Program, Preview).
+* **Toast Notifications** with severity color-coding; persistent banner for critical incidents until acknowledged.
+* **Empty States** providing call-to-action (e.g., "No cameras yet—add your first camera").
+* **Loading Skeletons** for previews while streams initialize and overlays render in preview canvas.
+* **Error Handling** includes inline hints, retry buttons, OCL validation error summaries with line references, and ability to download diagnostics from failure dialogs.
 
-   * **Preset List:** Table with shot names (e.g., shot1, shot2).
-   * **Add Preset Form:** Pan, tilt, zoom sliders/inputs.
-   * **Live Preview Window:** Adjust PTZ and save as preset.
-   * **Trigger Buttons:** Move camera to saved preset.
-
-5. **Streams**
-
-   * **Active Streams List:** Destination (YouTube, Facebook, Twitch), status, start time.
-   * **Add Stream Destination Form:** Select platform, enter RTMP URL/stream key.
-   * **Controls:** Start, stop, restart stream.
-
-6. **Overlays**
-
-   * **Overlay List:** Cached assets synced from VistterStudio.
-   * **Preview Panel:** Small thumbnails for overlays.
-   * **Sync Button:** Manual trigger to fetch latest overlays.
-
-7. **Settings**
-
-   * **User Management:** Change password.
-   * **System Settings:** Cache size, auto-reconnect toggles.
-   * **Authentication:** Local-only, reset password option.
-   * **Logs:** Download/view system logs.
-
-## Interaction Patterns
-
-* **Dashboard-first workflow:** Always land on camera overview.
-* **CRUD actions:** For cameras, presets, streams, overlays.
-* **Modal Dialogs:** For add/edit forms (camera, stream, preset).
-* **Live Previews:** Inline HLS/RTSP player in dashboard and camera detail.
-* **Status Indicators:** Color-coded dots for health (green = online, red = offline).
-* **Confirmation Dialogs:** For deletions or major changes.
-
-## Visual Design Elements & Color Scheme
-
+## 6. Visual Language
 * **Color Palette:**
+  * Midnight Gray (#1C1F2B) background, Deep Navy (#121521) panels.
+  * Primary Accent Azure (#1E90FF) for main actions.
+  * Success Green (#24D17B), Warning Amber (#FFC857), Error Crimson (#FF4D6D).
+  * Neutral grays for text (#F4F6FB for headings, #B5BED6 for body).
+* **Typography:** Inter as primary font with weights 400/500/600; monospaced font (JetBrains Mono) for logs.
+* **Iconography:** Feather or Heroicons for consistency; ensure tooltips and labels for accessibility.
+* **Card Design:** Rounded 8px corners, subtle elevation, status badge in top-right corner.
 
-  * Dark background (#1E1E1E)
-  * Accent blue (#007BFF) for primary actions
-  * Green (#28A745) for healthy/online
-  * Red (#DC3545) for error/offline
-  * Neutral grays for secondary text/buttons
-* **Branding:** VistterStream logo in sidebar and login screen.
-* **Card Style:** Rounded corners, soft shadows.
+## 7. Responsive Behavior
+* **Desktop (>1200px):** Three-column dashboard (metrics, cameras grid, alerts).
+* **Tablet (768–1199px):** Navigation collapses to icon rail; camera previews switch to two-column.
+* **Mobile (<768px):** Top nav converts to hamburger menu; key actions move to sticky footer for reachability; streaming previews optional due to bandwidth.
 
-## Mobile, Web App, Desktop Considerations
+## 8. Accessibility & Compliance
+* Meet WCAG 2.1 AA contrast ratios for text and interactive components.
+* Support full keyboard navigation and focus outlines, including PTZ controls via arrow keys.
+* Provide descriptive alt text for camera previews (camera name + status) and overlays.
+* Offer text-to-speech friendly alerts and ARIA live regions for real-time status updates.
 
-* **Responsive Web UI** (scales from desktop to tablet).
-* **Mobile-Friendly:** Dashboard collapses to list view; navigation sidebar collapses to bottom nav.
-* **Desktop Use:** Optimized for wide-screen monitoring, multiple camera previews side-by-side.
+## 9. Content Strategy
+* Use plain language labels ("Start Stream" instead of "Initiate Transmission").
+* Include inline help icons linking to docs or tooltips for technical terms (RTSP, bitrate).
+* Provide contextual success/error messaging with next-best actions ("Stream key invalid—update credentials") and segment-specific guidance ("Segment assets missing—revalidate or load from USB").
+* Logs and diagnostics formatted with timestamps, severity labels, and action tags.
 
-## Typography
+## 10. Future UX Enhancements
+* Multi-appliance switcher within UI for fleet management.
+* Embedded tutorial mode overlay guiding new operators.
+* Dark/light theme toggle for varying control room environments.
+* Mobile push notifications via PWA integration for alerting on the go.
 
-* **Primary Font:** Inter (sans-serif, clean, modern).
-* **Headings:** Bold, uppercase.
-* **Body Text:** Medium weight, high contrast.
-* **Status Indicators:** Paired with text labels for accessibility.
+## 11. Experience Planning & Traceability
+### 11.1 Alignment with PRD & SAD
+| UX Area | Supporting PRD Requirements | Supporting Architecture Elements | Notes |
+| --- | --- | --- | --- |
+| Setup Wizard & Auth | 6.1, 6.5 | Web/API Gateway, Persistence Layer | Validate copy and flow with first pilot customers behind firewalls. |
+| Camera & PTZ Controls | 6.2 | Camera Manager APIs, PTZ latency metrics | Ensure joystick interactions remain keyboard accessible. |
+| Timeline & Overlay Monitoring | 6.3, 6.7 | Control Service telemetry, Overlay Service cue reporting | Map overlay cue logs to advertiser reporting export. |
+| Segments Library & Playback | 6.3, 6.6 | Segment metadata store, orchestration state machine | Define manual override permissions by role. |
+| Alerts & Diagnostics | 6.6 | Metrics & Messaging, diagnostics bundle generator | Prototype alert resolution workflows with support team. |
 
-## Accessibility
+### 11.2 UX Research & Content Backlog
+1. Conduct contextual inquiry with two pilot venues to validate dashboard alert density and prioritization.
+2. Usability-test PTZ preset creation flow on touch devices to ensure controls remain usable without hardware keyboards.
+3. Draft microcopy guidelines for OCL validation errors so messaging is consistent across local UI and VistterStudio surfaces.
+4. Define visual treatment for offline/online states throughout navigation, including timeline cards and segment rows.
+5. Collaborate with engineering on telemetry dashboards that surface overlay cue drift in near real time.
 
-* **Contrast Ratios:** All text/buttons meet WCAG AA.
-* **Keyboard Navigation:** All forms and modals accessible with Tab/Enter.
-* **ARIA Labels:** For camera previews, status indicators, and buttons.
-* **Colorblind-Friendly:** Status icons paired with text labels (Online, Offline).
-
+### 11.3 Design Documentation To-Do
+* Produce responsive layout specs for 768px breakpoint for Cameras, Timelines, and Segments views.
+* Create component library starter in Figma with tokens for palette, typography, spacing, and elevation.
+* Document animation principles (durations, easing) for overlay previews and timeline transitions.
+* Establish accessibility acceptance checklist integrated into design review template.


### PR DESCRIPTION
## Summary
- add an iteration framework and decision log references to the PRD to guide future refinements
- extend the software architecture document with requirement traceability and an architecture backlog
- link UX guidance to product and architecture requirements while documenting upcoming research and design tasks

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68dc0ff47df4832fa3ddfccbc7b67e5d