### PR TITLE
Fix ProtectedRoute authentication handling

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "lucide-react": "^0.544.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^7.9.2",
+    "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,66 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { useAuth } from './contexts/AuthContext';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+jest.mock('./contexts/AuthContext', () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <div data-testid="auth-provider">{children}</div>,
+  useAuth: jest.fn()
+}));
+
+jest.mock('react-router-dom', () => ({
+  BrowserRouter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Routes: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Route: ({ element }: { element: React.ReactNode }) => <div>{element}</div>,
+  Navigate: ({ to, replace }: { to: string; replace?: boolean }) => (
+    <div data-testid="navigate" data-to={to} data-replace={String(Boolean(replace))}>
+      Navigate to {to}
+    </div>
+  )
+}));
+
+jest.mock('./components/Login', () => () => <div>Login Component</div>);
+jest.mock('./components/Dashboard', () => () => <div>Dashboard Component</div>);
+jest.mock('./components/CameraManagement', () => () => <div>Camera Management Component</div>);
+jest.mock('./components/StreamManagement', () => () => <div>Stream Management Component</div>);
+jest.mock('./components/PresetManagement', () => () => <div>Preset Management Component</div>);
+jest.mock('./components/Settings', () => () => <div>Settings Component</div>);
+jest.mock('./components/Layout', () => ({ children }: { children: React.ReactNode }) => (
+  <div data-testid="layout">{children}</div>
+));
+
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+describe('App routing with authentication', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects to the login route when unauthenticated', () => {
+    mockedUseAuth.mockReturnValue({
+      user: null,
+      loading: false,
+      login: jest.fn(),
+      logout: jest.fn()
+    });
+
+    render(<App />);
+
+    const navigateElements = screen.getAllByTestId('navigate');
+    expect(navigateElements[0]).toHaveAttribute('data-to', '/login');
+  });
+
+  it('renders protected content when authenticated', () => {
+    mockedUseAuth.mockReturnValue({
+      user: { id: 1, username: 'tester', is_active: true, created_at: 'today' },
+      loading: false,
+      login: jest.fn(),
+      logout: jest.fn()
+    });
+
+    render(<App />);
+
+    expect(screen.getAllByTestId('layout').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Dashboard Component').length).toBeGreaterThan(0);
+  });
 });

--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ProtectedRoute from './ProtectedRoute';
+import { useAuth } from '../contexts/AuthContext';
+
+jest.mock('../contexts/AuthContext', () => ({
+  useAuth: jest.fn()
+}));
+
+jest.mock('react-router-dom', () => ({
+  Navigate: ({ to, replace }: { to: string; replace?: boolean }) => (
+    <div data-testid="navigate" data-to={to} data-replace={String(Boolean(replace))}>
+      Navigate to {to}
+    </div>
+  )
+}));
+
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+describe('ProtectedRoute', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a loading indicator while authentication state is loading', () => {
+    mockedUseAuth.mockReturnValue({
+      user: null,
+      loading: true,
+      login: jest.fn(),
+      logout: jest.fn()
+    });
+
+    render(
+      <ProtectedRoute>
+        <div>Protected Content</div>
+      </ProtectedRoute>
+    );
+
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+    expect(screen.getByText(/loading.../i)).toBeInTheDocument();
+  });
+
+  it('redirects to login when there is no authenticated user', () => {
+    mockedUseAuth.mockReturnValue({
+      user: null,
+      loading: false,
+      login: jest.fn(),
+      logout: jest.fn()
+    });
+
+    render(
+      <ProtectedRoute>
+        <div>Protected Content</div>
+      </ProtectedRoute>
+    );
+
+    const navigateElement = screen.getByTestId('navigate');
+    expect(navigateElement).toHaveAttribute('data-to', '/login');
+    expect(navigateElement).toHaveAttribute('data-replace', 'true');
+  });
+
+  it('renders children when user is authenticated', () => {
+    mockedUseAuth.mockReturnValue({
+      user: { id: 1, username: 'test', is_active: true, created_at: 'today' },
+      loading: false,
+      login: jest.fn(),
+      logout: jest.fn()
+    });
+
+    render(
+      <ProtectedRoute>
+        <div>Protected Content</div>
+      </ProtectedRoute>
+    );
+
+    expect(screen.getByText('Protected Content')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -7,8 +7,20 @@ interface ProtectedRouteProps {
 }
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
-  // TEMPORARILY BYPASS AUTH FOR DEMO
-  console.log('ProtectedRoute: Bypassing auth for demo');
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen" role="status" aria-label="Loading">
+        <p className="text-gray-400">Loading...</p>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
   return <>{children}</>;
 };
 


### PR DESCRIPTION
## Summary
- update ProtectedRoute to wait on auth state, show a loading indicator, and redirect unauthenticated users to the login page
- expand unit tests to cover ProtectedRoute redirect and authenticated rendering paths while mocking routing/auth context dependencies
- adjust the frontend routing dependency version for compatibility with the existing tooling

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68dd4703246c832f88ffc8600c3cee9a