### PR TITLE
Document Codex-to-Pi deployment workflow steps

### DIFF
--- a/deploy/auto-deploy.conf
+++ b/deploy/auto-deploy.conf
@@ -1,0 +1,24 @@
+# Optional instructions for scripts/raspi_auto_deploy.sh
+#
+# Supported keys:
+#   branch=<git branch name>        # Default branch for all hosts
+#   branch[hostname]=<branch>       # Host-specific branch override
+#   script=<path to script>         # Relative path to execute instead of ./deploy.sh
+#   script[hostname]=<path>         # Host-specific script override
+#   args=<extra args>               # Arguments appended when invoking the script
+#   args[hostname]=<extra args>     # Host-specific argument override
+#   instruction_file=<path>         # Alternative instruction file for subsequent runs
+#
+# Remote coordination tips:
+# - Commit the instructions on the control branch (defaults to the remote HEAD,
+#   usually main). Every helper host will read the same directives before
+#   checking out the target branch.
+# - Use host overrides to let different environments track different branches,
+#   e.g. branch[raspi]=release, branch[codex]=work.
+#
+# Example:
+# branch=feature/youtube-oauth
+# branch[raspi]=feature/youtube-oauth
+# branch[codex]=work
+# script=./deploy.sh
+# args=--skip-frontend

--- a/docs/CODEX_DEPLOY_WORKFLOW.md
+++ b/docs/CODEX_DEPLOY_WORKFLOW.md
@@ -1,0 +1,90 @@
+# Codex + Raspberry Pi Deployment Workflow
+
+This guide describes how to collaborate with Codex (or other AI-assisted
+workspaces) while keeping the Raspberry Pi in sync using the auto-deploy helper.
+
+## 1. Develop inside Codex
+
+1. **Launch the workspace** – Open the repository in the Codex web IDE.
+2. **Choose your branch** – Create or check out the feature branch you want the
+   Raspberry Pi to test (e.g., `feature/youtube-oauth`).
+3. **Code & test** – Implement changes, run unit tests or linters inside the
+   Codex terminal, and review the diff.
+4. **Commit locally** – Use the built-in Git tooling (or the terminal) to commit
+   your work. Commit early so you always have a recoverable checkpoint.
+5. **Push to GitHub** – `git push origin <branch>` so the Raspberry Pi can fetch
+   the exact commits you want it to deploy.
+
+> Codex workspaces are disposable. Push every change you care about before you
+> close the session so the Pi—and other collaborators—can pull the branch.
+
+## 2. Describe the deployment plan
+
+1. Edit `deploy/auto-deploy.conf` on the control branch (defaults to
+   `origin/main`).
+2. Set host-specific directives so each environment follows the right branch.
+   Example:
+
+   ```
+   branch[raspi]=feature/youtube-oauth
+   branch[codex]=work
+   ```
+
+3. Commit the instruction changes. Every helper reads the same file before it
+   checks out the target branch.
+
+### Optional: alternate control branch
+
+If you do not want to modify `main`, create a lightweight coordination branch
+(e.g., `deploy/codex`) and push the instruction file there. On the Raspberry Pi
+run:
+
+```bash
+AUTO_DEPLOY_CONTROL_BRANCH=deploy/codex ./scripts/raspi_auto_deploy.sh
+```
+
+The helper reads directives from that branch while still pulling code from the
+branch specified in the instruction file.
+
+## 3. Update the Raspberry Pi
+
+1. **Connect to the Pi** – SSH into the device and change directories into the
+   repository (`cd ~/VistterStream`).
+2. **Run the helper** – Execute `./scripts/raspi_auto_deploy.sh`.
+3. **Let the helper sync** – It will:
+   - Fetch the latest commits and instruction file from GitHub.
+   - Switch to the branch specified for the Pi (for example,
+     `feature/youtube-oauth`).
+   - Run `deploy.sh` (or the alternative command you specified) to rebuild and
+     restart the Docker services.
+4. **Confirm the stack** – After the script exits, check service health:
+
+   ```bash
+   docker compose -f docker/docker-compose.rpi.yml ps
+   ```
+
+   Optionally follow up with the health endpoints listed in
+   `RASPBERRY_PI_SETUP.md`.
+
+## 4. Iterate and merge
+
+- Continue pushing updates from Codex (or other agents) as needed.
+- Adjust `deploy/auto-deploy.conf` whenever you want the Pi to track a different
+  branch.
+- Once the feature is validated, merge it into `main` through a pull request.
+  Update the instruction file to point the Pi back to `main` (e.g.,
+  `branch[raspi]=main`).
+
+## 5. End-to-end example checklist
+
+1. Push your Codex branch to GitHub.
+2. Edit `deploy/auto-deploy.conf` so `branch[raspi]` points at that branch.
+3. Commit and push the instruction update (same branch or control branch).
+4. SSH into the Raspberry Pi and run `./scripts/raspi_auto_deploy.sh`.
+5. Validate services with `docker compose -f docker/docker-compose.rpi.yml ps`
+   and the API/Frontend health checks.
+6. Iterate or merge once testing is complete.
+
+This workflow makes it easy to incorporate contributions from many agents: each
+one pushes their branch, updates the coordination file, and the Raspberry Pi
+fetches and deploys the correct code automatically.

--- a/scripts/raspi_auto_deploy.sh
+++ b/scripts/raspi_auto_deploy.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Automated deploy helper for Raspberry Pi hosts.
+# - Checks remote instructions for target branch/script
+# - Supports host-specific overrides so multiple agents can coordinate
+# - Keeps repo in sync with GitHub
+# - Delegates build logic to deploy.sh (or custom script)
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_DIR"
+
+log() { echo "[auto-deploy] $*"; }
+err() { echo "[auto-deploy][ERROR] $*" >&2; }
+
+trim() {
+  local var="$1"
+  var="${var#${var%%[![:space:]]*}}"
+  var="${var%${var##*[![:space:]]}}"
+  printf '%s' "$var"
+}
+
+apply_instruction_stream() {
+  local context="$1" allow_branch_override="$2" line raw_key value base target should_apply
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%%#*}"
+    line=$(trim "$line")
+    [[ -z "$line" ]] && continue
+    [[ "$line" != *=* ]] && continue
+
+    raw_key=$(trim "${line%%=*}")
+    value=$(trim "${line#*=}")
+
+    if [[ "$raw_key" =~ ^([A-Za-z0-9_-]+)(\[(.+)\])?$ ]]; then
+      base="${BASH_REMATCH[1]}"
+      target="${BASH_REMATCH[3]}"
+    else
+      base="$raw_key"
+      target=""
+    fi
+
+    should_apply=1
+    if [[ -n "$target" && "$target" != "$HOST_ID" ]]; then
+      should_apply=0
+    fi
+    if [[ "$should_apply" -eq 0 ]]; then
+      continue
+    fi
+
+    case "$base" in
+      branch)
+        if [[ -z "$value" ]]; then
+          continue
+        fi
+        if [[ "$allow_branch_override" == "1" ]]; then
+          TARGET_BRANCH="$value"
+        elif [[ "$value" != "$TARGET_BRANCH" ]]; then
+          log "Note: $context branch directive '$value' ignored (currently on '$TARGET_BRANCH')"
+        fi
+        ;;
+      script)
+        if [[ -n "$value" ]]; then
+          DEPLOY_SCRIPT="$value"
+        fi
+        ;;
+      args)
+        if [[ -n "$value" ]]; then
+          # shellcheck disable=SC2206
+          DEPLOY_ARGS=(${value})
+        fi
+        ;;
+      instruction_file)
+        if [[ -n "$value" ]]; then
+          if [[ "$allow_branch_override" == "1" ]]; then
+            INSTRUCTION_FILE="$value"
+          else
+            log "Note: $context instruction_file directive ignored after checkout"
+          fi
+        fi
+        ;;
+      *)
+        log "Ignoring unknown $context instruction key: $raw_key"
+        ;;
+    esac
+  done
+}
+
+REMOTE="${AUTO_DEPLOY_REMOTE:-origin}"
+INSTRUCTION_FILE="${AUTO_DEPLOY_INSTRUCTION_FILE:-deploy/auto-deploy.conf}"
+HOST_ID="${AUTO_DEPLOY_ID:-$(hostname -s 2>/dev/null || hostname)}"
+
+if ! command -v git >/dev/null 2>&1; then
+  err "git is required on the host"
+  exit 1
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [[ -z "$CURRENT_BRANCH" || "$CURRENT_BRANCH" == "HEAD" ]]; then
+  err "Repository is in a detached HEAD state. Check out a branch before running auto deploy."
+  exit 1
+fi
+
+TARGET_BRANCH="$CURRENT_BRANCH"
+DEPLOY_SCRIPT="./deploy.sh"
+DEPLOY_ARGS=()
+
+log "Repository root: $REPO_DIR"
+log "Host identifier: $HOST_ID"
+log "Current branch: $CURRENT_BRANCH"
+log "Checking remote '$REMOTE' for updates..."
+
+git fetch "$REMOTE" --prune
+
+CONTROL_BRANCH="${AUTO_DEPLOY_CONTROL_BRANCH:-}"
+if [[ -z "$CONTROL_BRANCH" ]]; then
+  CONTROL_BRANCH=$(git symbolic-ref --quiet --short "refs/remotes/${REMOTE}/HEAD" 2>/dev/null || echo "")
+  CONTROL_BRANCH="${CONTROL_BRANCH#${REMOTE}/}"
+fi
+if [[ -z "$CONTROL_BRANCH" ]]; then
+  CONTROL_BRANCH="$CURRENT_BRANCH"
+fi
+
+REMOTE_CONTROL_REF="$REMOTE/$CONTROL_BRANCH:$INSTRUCTION_FILE"
+if git cat-file -e "$REMOTE_CONTROL_REF" 2>/dev/null; then
+  log "Applying remote instructions from $REMOTE_CONTROL_REF"
+  apply_instruction_stream "remote" 1 < <(git show "$REMOTE_CONTROL_REF") || true
+else
+  log "No remote instruction file found at $REMOTE_CONTROL_REF; using defaults."
+fi
+
+if [[ "$TARGET_BRANCH" != "$CURRENT_BRANCH" ]]; then
+  log "Switching to target branch '$TARGET_BRANCH'"
+  if ! git ls-remote --exit-code "$REMOTE" "refs/heads/$TARGET_BRANCH" >/dev/null 2>&1; then
+    err "Target branch '$TARGET_BRANCH' not found on remote '$REMOTE'"
+    exit 1
+  fi
+  if git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
+    git checkout "$TARGET_BRANCH"
+  else
+    git checkout -t "$REMOTE/$TARGET_BRANCH"
+  fi
+else
+  log "Staying on branch '$TARGET_BRANCH'"
+fi
+
+log "Pulling latest commits for '$TARGET_BRANCH' from '$REMOTE'"
+if ! git pull --ff-only "$REMOTE" "$TARGET_BRANCH"; then
+  err "git pull failed. Resolve issues and rerun."
+  exit 1
+fi
+
+if [[ -f "$INSTRUCTION_FILE" ]]; then
+  log "Applying local instructions from $INSTRUCTION_FILE"
+  apply_instruction_stream "local" 0 < "$INSTRUCTION_FILE"
+else
+  log "No local instruction file present; using defaults."
+fi
+
+if [[ ! -e "$DEPLOY_SCRIPT" ]]; then
+  err "Deploy script '$DEPLOY_SCRIPT' not found"
+  exit 1
+fi
+if [[ ! -x "$DEPLOY_SCRIPT" ]]; then
+  log "Making deploy script executable: $DEPLOY_SCRIPT"
+  chmod +x "$DEPLOY_SCRIPT"
+fi
+
+log "Final target branch: $TARGET_BRANCH"
+log "Executing on host '$HOST_ID' using: $DEPLOY_SCRIPT ${DEPLOY_ARGS[*]}"
+
+log "Invoking $DEPLOY_SCRIPT ${DEPLOY_ARGS[*]}"
+"$DEPLOY_SCRIPT" "${DEPLOY_ARGS[@]}"


### PR DESCRIPTION
## Summary
- clarify Codex workspace usage steps and Git push requirements before Raspberry Pi testing
- expand Raspberry Pi guide with a quick reference loop for syncing branches via the auto-deploy helper
- add an end-to-end checklist for Codex-to-Pi deployments covering instruction updates and verification

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69022a61cec4832f8e7b77f06a894abc